### PR TITLE
Updates for Beman project repository transfer

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Distributed under the Boost Software License, Version 1.0.
 
 # beman.utf_view: C++26 UTF Transcoding Views
 
-[![CI](https://github.com/ednolan/utf_view/actions/workflows/ci.yml/badge.svg)](https://github.com/ednolan/utf_view/actions) [![Coverage](https://coveralls.io/repos/github/ednolan/utf_view/badge.svg?branch=main)](https://coveralls.io/github/ednolan/utf_view?branch=main)
+[![CI](https://github.com/beman-project/utf_view/actions/workflows/ci.yml/badge.svg)](https://github.com/beman-project/utf_view/actions) [![Coverage](https://coveralls.io/repos/github/beman-project/utf_view/badge.svg?branch=main)](https://coveralls.io/github/beman-project/utf_view?branch=main)
 
 This repository implements the functionality proposed by P2728 for C++26, including:
 
@@ -135,7 +135,7 @@ This excerpt from the project's CI script provides an example of building the pr
 beman.utf_view is based on P2728.
 
 - The latest official revision of P2728 can be found at https://wg21.link/p2728
-- The unofficial latest draft Markdown source for the paper can be found in this repository at [paper/P2828.md](https://github.com/ednolan/utf_view/blob/main/paper/P2728.md)
+- The unofficial latest draft Markdown source for the paper can be found in this repository at [paper/P2828.md](https://github.com/beman-project/utf_view/blob/main/paper/P2728.md)
 - The paper's committee status page can be found at https://github.com/cplusplus/papers/issues/1422
 
 ## Authors

--- a/paper/P2728.md
+++ b/paper/P2728.md
@@ -6168,9 +6168,9 @@ __Outcome:__ Strong consensus in favor
 # Implementation experience
 
 The most recent revision of this paper has a reference implementation called
-[utf_view](https://github.com/ednolan/utf_view) available on GitHub, which is a
-fork of Jonathan Wakely's implementation of P2728R6 as an implementation
-detail for libstdc++.
+[beman.utf_view](https://github.com/beman-project/utf_view) available on
+GitHub, which is a fork of Jonathan Wakely's implementation of P2728R6 as an
+implementation detail for libstdc++. It is part of the Beman project.
 
 Versions of the interfaces provided by previous revisions of this paper have
 also been implemented, and re-implemented, several times over the last 5 years


### PR DESCRIPTION
- In the README, update the CI and coverage badges and the link to the paper markdown to reflect the new URL
- In the paper, update the link to this repository to reflect the new URL